### PR TITLE
Benchmarks + improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ module foo.bar {
 
 What differentiates Deezpatch from other messaging/dispatch libraries? The library utilizes the benefits provided by [java.lang.invoke.LambdaMetafactory](https://docs.oracle.com/javase/8/docs/api/java/lang/invoke/LambdaMetafactory.html) to avoid the cost of invoking methods reflectively. This results in performance close to directly invoking the methods.
 
+### [Java 11 Benchmarks](https://jmh.morethan.io/?source=https://raw.githubusercontent.com/joeljeremy7/deezpatch/main/core/src/jmh/results-java11.json)
+
+### [Java 17 Benchmarks](https://jmh.morethan.io/?source=https://raw.githubusercontent.com/joeljeremy7/deezpatch/main/core/src/jmh/results-java17.json)
+
 ## ✉️ Requests
 
 Requests are messages that either:

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: "me.champeau.jmh"
+
 description = "Deezpatch Core"
 
 jar {
@@ -6,4 +8,18 @@ jar {
             "Automatic-Module-Name": "io.github.joeljeremy7.deezpatch.core"
         )
     }
+}
+
+dependencies {
+    jmh "org.springframework:spring-context:5.3.22"
+    jmh "net.sizovs:pipelinr:0.7"
+    jmh "org.greenrobot:eventbus-java:3.3.1"
+}
+
+jmh {
+    jmhVersion = "1.35"
+    humanOutputFile = project.file("${project.buildDir}/reports/jmh/human.txt")
+    resultsFile = project.file("${project.buildDir}/reports/jmh/results.json")
+    resultFormat = "JSON"
+    jvmArgs = [ "-Xmx2G" ]
 }

--- a/core/src/jmh/java/io/github/joeljeremy7/deezpatch/core/benchmarks/Benchmarks.java
+++ b/core/src/jmh/java/io/github/joeljeremy7/deezpatch/core/benchmarks/Benchmarks.java
@@ -1,0 +1,219 @@
+package io.github.joeljeremy7.deezpatch.core.benchmarks;
+
+import an.awesome.pipelinr.Command;
+import an.awesome.pipelinr.Notification;
+import an.awesome.pipelinr.Pipelinr;
+import an.awesome.pipelinr.Voidy;
+import io.github.joeljeremy7.deezpatch.core.Deezpatch;
+import io.github.joeljeremy7.deezpatch.core.Event;
+import io.github.joeljeremy7.deezpatch.core.EventHandler;
+import io.github.joeljeremy7.deezpatch.core.Request;
+import io.github.joeljeremy7.deezpatch.core.RequestHandler;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.context.support.GenericApplicationContext;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+@Warmup(time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(time = 5, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 2)
+public abstract class Benchmarks {
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+        private DeezpatchRequest deezpatchRequest;
+        private DeezpatchRequestHandler deezpatchRequestHandler;
+        private Deezpatch deezpatchRequestDispatcher;
+        private DeezpatchEvent deezpatchEvent;
+        private DeezpatchEventHandler deezpatchEventHandler;
+        private Deezpatch deezpatchEventPublisher;
+
+        private SpringEvent springEvent;
+        private SpringEventListener springEventListener;
+        private ApplicationEventPublisher springEventPublisher;
+
+        private PipelinrCommand pipelinrCommand;
+        private PipelinrCommandHandler pipelinrCommandHandler;
+        private Pipelinr commandPipelinr;
+        private PipelinrNotification pipelinrNotification;
+        private PipelinrNotificationHandler pipelinrNotificationHandler;
+        private Pipelinr notificationPipelinr;
+
+        private EventBusMessage eventBusMessage;
+        private EventBusSubsriber eventBusSubscriber;
+        private EventBus eventBus;
+
+        @Setup
+        public void setup() throws Throwable {
+            // Deezpatch.
+
+            deezpatchRequest = new DeezpatchRequest();
+            deezpatchRequestHandler = new DeezpatchRequestHandler();
+            deezpatchRequestDispatcher = Deezpatch.builder()
+                .instanceProvider(c -> deezpatchRequestHandler)
+                .requests(config -> 
+                    config.register(DeezpatchRequestHandler.class)
+                )
+                .build();
+            
+            deezpatchEvent = new DeezpatchEvent();
+            deezpatchEventHandler = new DeezpatchEventHandler();
+            deezpatchEventPublisher = Deezpatch.builder()
+                .instanceProvider(c -> deezpatchEventHandler)
+                .events(config -> 
+                    config.register(DeezpatchEventHandler.class)
+                )
+                .build();
+
+            // Spring
+
+            springEvent = new SpringEvent();
+            springEventListener = new SpringEventListener();
+            var context = new GenericApplicationContext();
+            context.registerBean(SpringEventListener.class, () -> springEventListener);
+            context.refresh();
+            springEventPublisher = context;
+
+            // Pipelinr
+
+            pipelinrCommandHandler = new PipelinrCommandHandler();
+            pipelinrCommand = new PipelinrCommand();
+            commandPipelinr = new Pipelinr()
+                .with(() -> Stream.of(pipelinrCommandHandler));
+            
+            pipelinrNotificationHandler = new PipelinrNotificationHandler();
+            pipelinrNotification = new PipelinrNotification();
+            notificationPipelinr = new Pipelinr()
+                .with(() -> Stream.of(pipelinrNotificationHandler));
+
+            // EventBus
+            eventBusMessage = new EventBusMessage();
+            eventBusSubscriber = new EventBusSubsriber();
+            eventBus = EventBus.getDefault();
+            eventBus.register(eventBusSubscriber);
+        }
+    }
+
+    /**
+     * Benchmarks that measure average time.
+     */
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public static class BenchmarksAvgt extends Benchmarks {}
+
+    /**
+     * Benchmarks that measure throughput.
+     */
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    public static class BenchmarksThrpt extends Benchmarks {}
+
+    @Benchmark
+    public void deezpatchEvent(BenchmarkState state, Blackhole blackhole) {
+        state.deezpatchEventPublisher.publish(state.deezpatchEvent);
+        blackhole.consume(state.deezpatchEvent);
+    }
+
+    @Benchmark
+    public void springEvent(BenchmarkState state, Blackhole blackhole) {
+        state.springEventPublisher.publishEvent(state.springEvent);
+        blackhole.consume(state.springEvent);
+    }
+
+    @Benchmark
+    public void pipelinrNotification(BenchmarkState state, Blackhole blackhole) {
+        state.notificationPipelinr.send(state.pipelinrNotification);
+        blackhole.consume(state.pipelinrNotification);
+    }
+
+    @Benchmark
+    public void eventBusEvent(BenchmarkState state, Blackhole blackhole) {
+        state.eventBus.post(state.eventBusMessage);
+        blackhole.consume(state.eventBusMessage);
+    }
+
+    // Single dispatch benchmarks.
+
+    @Benchmark
+    public void deezpatchRequest(BenchmarkState state, Blackhole blackhole) {
+        state.deezpatchRequestDispatcher.send(state.deezpatchRequest);
+        blackhole.consume(state.deezpatchRequest);
+    }
+
+    @Benchmark
+    public void pipelinrCommand(BenchmarkState state, Blackhole blackhole) {
+        state.commandPipelinr.send(state.pipelinrCommand);
+        blackhole.consume(state.pipelinrCommand);
+    }
+
+    public static class DeezpatchRequest implements Request<Void> {}
+
+    public static class DeezpatchRequestHandler {
+        @RequestHandler
+        public void handle(DeezpatchRequest request) {
+            // No-op.
+        }
+    }
+
+    public static class DeezpatchEvent implements Event {}
+
+    public static class DeezpatchEventHandler {
+        @EventHandler
+        public void handle(DeezpatchEvent event) {
+            // No-op.
+        }
+    }
+
+    public static class SpringEvent {}
+
+    public static class SpringEventListener {
+        @EventListener
+        public void handle(SpringEvent event) {
+            // No-op.
+        }
+    }
+
+    public static class PipelinrCommand implements Command<Voidy> {}
+
+    public static class PipelinrCommandHandler 
+            implements Command.Handler<PipelinrCommand, Voidy> {
+        @Override
+        public Voidy handle(PipelinrCommand command) {
+            // No-op.
+            return null;
+        }
+    }
+
+    public static class PipelinrNotification implements Notification {}
+
+    public static class PipelinrNotificationHandler 
+            implements Notification.Handler<PipelinrNotification> {
+        @Override
+        public void handle(PipelinrNotification notification) {
+            // No-op.
+        }
+    }
+
+    public static class EventBusMessage {}
+
+    public static class EventBusSubsriber {
+        @Subscribe
+        public void handle(EventBusMessage event) {
+            // No-op.
+        }
+    }
+}

--- a/core/src/jmh/java/io/github/joeljeremy7/deezpatch/core/benchmarks/results-java11.json
+++ b/core/src/jmh/java/io/github/joeljeremy7/deezpatch/core/benchmarks/results-java11.json
@@ -1,0 +1,712 @@
+[
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.deezpatchEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 49131.919779328295,
+            "scoreError" : 1284.824238366928,
+            "scoreConfidence" : [
+                47847.09554096137,
+                50416.74401769522
+            ],
+            "scorePercentiles" : {
+                "0.0" : 48092.89285700381,
+                "50.0" : 48982.93021075783,
+                "90.0" : 50218.59892557588,
+                "95.0" : 50233.351189516514,
+                "99.0" : 50233.351189516514,
+                "99.9" : 50233.351189516514,
+                "99.99" : 50233.351189516514,
+                "99.999" : 50233.351189516514,
+                "99.9999" : 50233.351189516514,
+                "100.0" : 50233.351189516514
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    48489.95192066325,
+                    48092.89285700381,
+                    48278.350104560355,
+                    48541.56608042815,
+                    48386.34173528342
+                ],
+                [
+                    49953.44518660103,
+                    49424.294341087516,
+                    50085.82855011017,
+                    50233.351189516514,
+                    49833.17582802872
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.deezpatchRequest",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 60281.712189321974,
+            "scoreError" : 1669.5007221877859,
+            "scoreConfidence" : [
+                58612.211467134184,
+                61951.21291150976
+            ],
+            "scorePercentiles" : {
+                "0.0" : 58977.892908346956,
+                "50.0" : 60374.64960974945,
+                "90.0" : 61416.284333152435,
+                "95.0" : 61416.68991608697,
+                "99.0" : 61416.68991608697,
+                "99.9" : 61416.68991608697,
+                "99.99" : 61416.68991608697,
+                "99.999" : 61416.68991608697,
+                "99.9999" : 61416.68991608697,
+                "100.0" : 61416.68991608697
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    61416.68991608697,
+                    61412.634086741615,
+                    61235.57395141522,
+                    61144.982381830014,
+                    61358.758939449035
+                ],
+                [
+                    59116.9381559862,
+                    59604.31683766889,
+                    58977.892908346956,
+                    59430.67156224164,
+                    59118.6631534531
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.eventBusEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 17028.380781061584,
+            "scoreError" : 206.09471697084172,
+            "scoreConfidence" : [
+                16822.286064090742,
+                17234.475498032425
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16675.152852305266,
+                "50.0" : 17060.459814920658,
+                "90.0" : 17158.41166152666,
+                "95.0" : 17162.836503058625,
+                "99.0" : 17162.836503058625,
+                "99.9" : 17162.836503058625,
+                "99.99" : 17162.836503058625,
+                "99.999" : 17162.836503058625,
+                "99.9999" : 17162.836503058625,
+                "100.0" : 17162.836503058625
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    17036.149738676253,
+                    17162.836503058625,
+                    16954.027696774952,
+                    16675.152852305266,
+                    17052.733560307257
+                ],
+                [
+                    17032.630114928048,
+                    17068.18606953406,
+                    17106.64902876814,
+                    17118.588087739,
+                    17076.854158524224
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.pipelinrCommand",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6784.709172811912,
+            "scoreError" : 241.79710070847563,
+            "scoreConfidence" : [
+                6542.912072103437,
+                7026.506273520387
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6430.266988432037,
+                "50.0" : 6809.233881809216,
+                "90.0" : 6936.403100035098,
+                "95.0" : 6937.8247767732055,
+                "99.0" : 6937.8247767732055,
+                "99.9" : 6937.8247767732055,
+                "99.99" : 6937.8247767732055,
+                "99.999" : 6937.8247767732055,
+                "99.9999" : 6937.8247767732055,
+                "100.0" : 6937.8247767732055
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    6918.673084646434,
+                    6899.766982894133,
+                    6923.608009392129,
+                    6937.8247767732055,
+                    6881.861132954156
+                ],
+                [
+                    6430.266988432037,
+                    6718.37239659667,
+                    6709.3552479669925,
+                    6736.606630664274,
+                    6690.756477799098
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.pipelinrNotification",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5262.019961280226,
+            "scoreError" : 122.40082889224813,
+            "scoreConfidence" : [
+                5139.619132387978,
+                5384.420790172474
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5139.962286066061,
+                "50.0" : 5269.118564900879,
+                "90.0" : 5362.2081695526995,
+                "95.0" : 5365.157068305706,
+                "99.0" : 5365.157068305706,
+                "99.9" : 5365.157068305706,
+                "99.99" : 5365.157068305706,
+                "99.999" : 5365.157068305706,
+                "99.9999" : 5365.157068305706,
+                "100.0" : 5365.157068305706
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    5169.514524086226,
+                    5227.180435047245,
+                    5207.854229466879,
+                    5202.747169197624,
+                    5139.962286066061
+                ],
+                [
+                    5333.858915802711,
+                    5365.157068305706,
+                    5335.668080775636,
+                    5311.056694754514,
+                    5327.200209299652
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.springEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4080.3385473947164,
+            "scoreError" : 141.4223606060184,
+            "scoreConfidence" : [
+                3938.916186788698,
+                4221.760908000735
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3983.8275406701146,
+                "50.0" : 4072.4014138890407,
+                "90.0" : 4186.259521641423,
+                "95.0" : 4186.602998572936,
+                "99.0" : 4186.602998572936,
+                "99.9" : 4186.602998572936,
+                "99.99" : 4186.602998572936,
+                "99.999" : 4186.602998572936,
+                "99.9999" : 4186.602998572936,
+                "100.0" : 4186.602998572936
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    4183.168229257808,
+                    4169.227788688676,
+                    4186.602998572936,
+                    4140.200062840852,
+                    4161.51291031647
+                ],
+                [
+                    3994.580600809114,
+                    3993.243825899531,
+                    4004.6027649372295,
+                    3986.418751954437,
+                    3983.8275406701146
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.deezpatchEvent",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 20.08623166124461,
+            "scoreError" : 2.2977815495820884,
+            "scoreConfidence" : [
+                17.788450111662524,
+                22.384013210826698
+            ],
+            "scorePercentiles" : {
+                "0.0" : 17.89599123718923,
+                "50.0" : 20.00860181114127,
+                "90.0" : 22.945169145708373,
+                "95.0" : 23.06270046442894,
+                "99.0" : 23.06270046442894,
+                "99.9" : 23.06270046442894,
+                "99.99" : 23.06270046442894,
+                "99.999" : 23.06270046442894,
+                "99.9999" : 23.06270046442894,
+                "100.0" : 23.06270046442894
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    17.89599123718923,
+                    18.334566032308953,
+                    21.887387277223276,
+                    23.06270046442894,
+                    19.299390278166715
+                ],
+                [
+                    20.40257595473979,
+                    19.799942973382286,
+                    19.9842891157083,
+                    20.03291450657424,
+                    20.162558772724402
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.deezpatchRequest",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 19.81255118181268,
+            "scoreError" : 5.637642020103432,
+            "scoreConfidence" : [
+                14.174909161709248,
+                25.45019320191611
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16.235575070596752,
+                "50.0" : 19.799650936955082,
+                "90.0" : 23.490383340119028,
+                "95.0" : 23.497944687219455,
+                "99.0" : 23.497944687219455,
+                "99.9" : 23.497944687219455,
+                "99.99" : 23.497944687219455,
+                "99.999" : 23.497944687219455,
+                "99.9999" : 23.497944687219455,
+                "100.0" : 23.497944687219455
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    16.254582011383842,
+                    16.27628341979281,
+                    16.33840971249645,
+                    16.235575070596752,
+                    16.27349487556333
+                ],
+                [
+                    23.26089216141371,
+                    23.422331216215184,
+                    23.270653682827557,
+                    23.497944687219455,
+                    23.295344980617717
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.eventBusEvent",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 57.278380591479575,
+            "scoreError" : 0.7991503340015643,
+            "scoreConfidence" : [
+                56.47923025747801,
+                58.07753092548114
+            ],
+            "scorePercentiles" : {
+                "0.0" : 56.68018964539218,
+                "50.0" : 57.26935296507672,
+                "90.0" : 58.43529629949139,
+                "95.0" : 58.5416082769418,
+                "99.0" : 58.5416082769418,
+                "99.9" : 58.5416082769418,
+                "99.99" : 58.5416082769418,
+                "99.999" : 58.5416082769418,
+                "99.9999" : 58.5416082769418,
+                "100.0" : 58.5416082769418
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    56.86012477260023,
+                    58.5416082769418,
+                    57.2837059224251,
+                    56.72524032847002,
+                    56.68018964539218
+                ],
+                [
+                    57.465624953173005,
+                    57.279802845108705,
+                    57.2101175832023,
+                    57.4784885024377,
+                    57.258903085044736
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.pipelinrCommand",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 145.72649422438943,
+            "scoreError" : 11.180035568118036,
+            "scoreConfidence" : [
+                134.5464586562714,
+                156.90652979250746
+            ],
+            "scorePercentiles" : {
+                "0.0" : 138.112937032519,
+                "50.0" : 145.21830420571374,
+                "90.0" : 155.45049016061435,
+                "95.0" : 155.75160361312192,
+                "99.0" : 155.75160361312192,
+                "99.9" : 155.75160361312192,
+                "99.99" : 155.75160361312192,
+                "99.999" : 155.75160361312192,
+                "99.9999" : 155.75160361312192,
+                "100.0" : 155.75160361312192
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    138.112937032519,
+                    139.2299463309868,
+                    138.7445185863037,
+                    138.7475266861883,
+                    139.23213355037495
+                ],
+                [
+                    151.56254775001014,
+                    151.20447486105252,
+                    152.74046908804624,
+                    155.75160361312192,
+                    151.93878474529063
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.pipelinrNotification",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 177.8985897934133,
+            "scoreError" : 2.538083525922878,
+            "scoreConfidence" : [
+                175.36050626749042,
+                180.43667331933617
+            ],
+            "scorePercentiles" : {
+                "0.0" : 175.88253615478976,
+                "50.0" : 178.60888155192987,
+                "90.0" : 180.4328146947554,
+                "95.0" : 180.58245232444932,
+                "99.0" : 180.58245232444932,
+                "99.9" : 180.58245232444932,
+                "99.99" : 180.58245232444932,
+                "99.999" : 180.58245232444932,
+                "99.9999" : 180.58245232444932,
+                "100.0" : 180.58245232444932
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    178.89933460956834,
+                    180.58245232444932,
+                    178.59139906412253,
+                    178.62636403973724,
+                    178.96337825062764
+                ],
+                [
+                    179.08607602751016,
+                    175.88253615478976,
+                    176.19921374082944,
+                    176.1828444771187,
+                    175.97229924537996
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.springEvent",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@11/11.0.16.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "11.0.16.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "11.0.16.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 239.0990546596234,
+            "scoreError" : 1.5506839845566052,
+            "scoreConfidence" : [
+                237.5483706750668,
+                240.64973864418
+            ],
+            "scorePercentiles" : {
+                "0.0" : 237.5713990902811,
+                "50.0" : 239.28674056713595,
+                "90.0" : 240.45476483421683,
+                "95.0" : 240.47690752454145,
+                "99.0" : 240.47690752454145,
+                "99.9" : 240.47690752454145,
+                "99.99" : 240.47690752454145,
+                "99.999" : 240.47690752454145,
+                "99.9999" : 240.47690752454145,
+                "100.0" : 240.47690752454145
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    238.07872350991394,
+                    238.151544764296,
+                    240.14472822420942,
+                    238.2821666405277,
+                    237.5713990902811
+                ],
+                [
+                    239.45611508689728,
+                    239.31058072506445,
+                    240.2554806212953,
+                    239.26290040920745,
+                    240.47690752454145
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/core/src/jmh/java/io/github/joeljeremy7/deezpatch/core/benchmarks/results-java17.json
+++ b/core/src/jmh/java/io/github/joeljeremy7/deezpatch/core/benchmarks/results-java17.json
@@ -1,0 +1,712 @@
+[
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.deezpatchEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 63796.72674960231,
+            "scoreError" : 9140.192015614271,
+            "scoreConfidence" : [
+                54656.53473398804,
+                72936.91876521659
+            ],
+            "scorePercentiles" : {
+                "0.0" : 49353.51878614574,
+                "50.0" : 66493.56753137248,
+                "90.0" : 67716.47835691173,
+                "95.0" : 67723.61771892516,
+                "99.0" : 67723.61771892516,
+                "99.9" : 67723.61771892516,
+                "99.99" : 67723.61771892516,
+                "99.999" : 67723.61771892516,
+                "99.9999" : 67723.61771892516,
+                "100.0" : 67723.61771892516
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    67576.529569868,
+                    67480.04929604918,
+                    67100.86561839511,
+                    67652.22409879082,
+                    67723.61771892516
+                ],
+                [
+                    62922.59873985398,
+                    65135.620384207046,
+                    49353.51878614574,
+                    57135.97383943822,
+                    65886.26944434986
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.deezpatchRequest",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 51653.216525414355,
+            "scoreError" : 590.8811060433547,
+            "scoreConfidence" : [
+                51062.335419371,
+                52244.09763145771
+            ],
+            "scorePercentiles" : {
+                "0.0" : 50997.79200621457,
+                "50.0" : 51785.51685598035,
+                "90.0" : 52060.30666625467,
+                "95.0" : 52067.12564059259,
+                "99.0" : 52067.12564059259,
+                "99.9" : 52067.12564059259,
+                "99.99" : 52067.12564059259,
+                "99.999" : 52067.12564059259,
+                "99.9999" : 52067.12564059259,
+                "100.0" : 52067.12564059259
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    51970.764618040565,
+                    51187.983201701165,
+                    51291.72462767207,
+                    51910.543948119564,
+                    51998.93589721336
+                ],
+                [
+                    51978.58900142206,
+                    52067.12564059259,
+                    51468.21654932647,
+                    51660.489763841135,
+                    50997.79200621457
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.eventBusEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 14636.742328245411,
+            "scoreError" : 242.14031294577194,
+            "scoreConfidence" : [
+                14394.602015299639,
+                14878.882641191183
+            ],
+            "scorePercentiles" : {
+                "0.0" : 14268.543778763944,
+                "50.0" : 14631.458343284863,
+                "90.0" : 14802.39692568474,
+                "95.0" : 14804.142481548774,
+                "99.0" : 14804.142481548774,
+                "99.9" : 14804.142481548774,
+                "99.99" : 14804.142481548774,
+                "99.999" : 14804.142481548774,
+                "99.9999" : 14804.142481548774,
+                "100.0" : 14804.142481548774
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    14618.106559527445,
+                    14626.245031145132,
+                    14503.855000880852,
+                    14626.905745388343,
+                    14636.010941181385
+                ],
+                [
+                    14720.090690955321,
+                    14268.543778763944,
+                    14776.836130154492,
+                    14786.686922908424,
+                    14804.142481548774
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.pipelinrCommand",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6090.31968157429,
+            "scoreError" : 319.7540408866446,
+            "scoreConfidence" : [
+                5770.565640687646,
+                6410.073722460935
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5832.544513666683,
+                "50.0" : 6102.6973539797855,
+                "90.0" : 6317.115989906222,
+                "95.0" : 6317.974304710385,
+                "99.0" : 6317.974304710385,
+                "99.9" : 6317.974304710385,
+                "99.99" : 6317.974304710385,
+                "99.999" : 6317.974304710385,
+                "99.9999" : 6317.974304710385,
+                "100.0" : 6317.974304710385
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    5980.731467528556,
+                    5915.779716287189,
+                    5855.374435790129,
+                    5888.070262154194,
+                    5832.544513666683
+                ],
+                [
+                    6304.735275697485,
+                    6309.391156668757,
+                    6273.932442808511,
+                    6224.663240431014,
+                    6317.974304710385
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.pipelinrNotification",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5469.891716709082,
+            "scoreError" : 285.79192020459857,
+            "scoreConfidence" : [
+                5184.0997965044835,
+                5755.683636913681
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5279.13657999644,
+                "50.0" : 5394.389170495731,
+                "90.0" : 5862.686464442816,
+                "95.0" : 5892.597418693586,
+                "99.0" : 5892.597418693586,
+                "99.9" : 5892.597418693586,
+                "99.99" : 5892.597418693586,
+                "99.999" : 5892.597418693586,
+                "99.9999" : 5892.597418693586,
+                "100.0" : 5892.597418693586
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    5892.597418693586,
+                    5354.576887945205,
+                    5593.487876185881,
+                    5565.035690238326,
+                    5578.5840218065505
+                ],
+                [
+                    5337.23377004736,
+                    5309.486581186012,
+                    5359.988817067992,
+                    5279.13657999644,
+                    5428.789523923471
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksThrpt.springEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4168.792793835136,
+            "scoreError" : 62.21347089139661,
+            "scoreConfidence" : [
+                4106.5793229437395,
+                4231.006264726532
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4091.5685384555713,
+                "50.0" : 4169.1983901862895,
+                "90.0" : 4212.23734572581,
+                "95.0" : 4212.571617804923,
+                "99.0" : 4212.571617804923,
+                "99.9" : 4212.571617804923,
+                "99.99" : 4212.571617804923,
+                "99.999" : 4212.571617804923,
+                "99.9999" : 4212.571617804923,
+                "100.0" : 4212.571617804923
+            },
+            "scoreUnit" : "ops/ms",
+            "rawData" : [
+                [
+                    4209.228897013788,
+                    4212.571617804923,
+                    4205.136869237826,
+                    4208.142363439226,
+                    4183.346909922812
+                ],
+                [
+                    4139.279770264828,
+                    4091.5685384555713,
+                    4133.836776114038,
+                    4149.7663256485785,
+                    4155.049870449767
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.deezpatchEvent",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 14.754066593260095,
+            "scoreError" : 0.1401159832314841,
+            "scoreConfidence" : [
+                14.613950610028612,
+                14.894182576491579
+            ],
+            "scorePercentiles" : {
+                "0.0" : 14.65277687321415,
+                "50.0" : 14.728534235739954,
+                "90.0" : 14.939494261466944,
+                "95.0" : 14.948444358523794,
+                "99.0" : 14.948444358523794,
+                "99.9" : 14.948444358523794,
+                "99.99" : 14.948444358523794,
+                "99.999" : 14.948444358523794,
+                "99.9999" : 14.948444358523794,
+                "100.0" : 14.948444358523794
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    14.858943387955296,
+                    14.791476773357315,
+                    14.715888213915362,
+                    14.778866423159759,
+                    14.679575745564154
+                ],
+                [
+                    14.689331556923875,
+                    14.684182342422721,
+                    14.948444358523794,
+                    14.741180257564546,
+                    14.65277687321415
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.deezpatchRequest",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 19.21196030928465,
+            "scoreError" : 0.21416021021667428,
+            "scoreConfidence" : [
+                18.997800099067973,
+                19.426120519501325
+            ],
+            "scorePercentiles" : {
+                "0.0" : 19.042963374010753,
+                "50.0" : 19.18520306887621,
+                "90.0" : 19.49036531304984,
+                "95.0" : 19.508951842430854,
+                "99.0" : 19.508951842430854,
+                "99.9" : 19.508951842430854,
+                "99.99" : 19.508951842430854,
+                "99.999" : 19.508951842430854,
+                "99.9999" : 19.508951842430854,
+                "100.0" : 19.508951842430854
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    19.508951842430854,
+                    19.1255491237831,
+                    19.109554249445843,
+                    19.07365353420824,
+                    19.313520873558197
+                ],
+                [
+                    19.162253850248266,
+                    19.042963374010753,
+                    19.208152287504152,
+                    19.323086548620722,
+                    19.251917409036356
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.eventBusEvent",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 70.46568578768496,
+            "scoreError" : 3.332664049099225,
+            "scoreConfidence" : [
+                67.13302173858574,
+                73.79834983678418
+            ],
+            "scorePercentiles" : {
+                "0.0" : 67.87227449348117,
+                "50.0" : 71.06692983911475,
+                "90.0" : 72.62570797000184,
+                "95.0" : 72.63293474788581,
+                "99.0" : 72.63293474788581,
+                "99.9" : 72.63293474788581,
+                "99.99" : 72.63293474788581,
+                "99.999" : 72.63293474788581,
+                "99.9999" : 72.63293474788581,
+                "100.0" : 72.63293474788581
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    72.39956474942353,
+                    72.46378929635668,
+                    72.63293474788581,
+                    72.5606669690461,
+                    72.40820355019504
+                ],
+                [
+                    69.73429492880598,
+                    68.71930899816944,
+                    67.87227449348117,
+                    67.91842361117287,
+                    67.94739653231296
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.pipelinrCommand",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 162.36149515883616,
+            "scoreError" : 3.1190327767722654,
+            "scoreConfidence" : [
+                159.2424623820639,
+                165.48052793560842
+            ],
+            "scorePercentiles" : {
+                "0.0" : 159.00488592446476,
+                "50.0" : 162.66196898242526,
+                "90.0" : 165.05210972106022,
+                "95.0" : 165.0796615067828,
+                "99.0" : 165.0796615067828,
+                "99.9" : 165.0796615067828,
+                "99.99" : 165.0796615067828,
+                "99.999" : 165.0796615067828,
+                "99.9999" : 165.0796615067828,
+                "100.0" : 165.0796615067828
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    160.075812499986,
+                    160.8747657399033,
+                    160.92842141099817,
+                    162.451323238387,
+                    164.80414364955686
+                ],
+                [
+                    159.00488592446476,
+                    163.71151330629922,
+                    165.0796615067828,
+                    162.87261472646355,
+                    163.81180958552025
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.pipelinrNotification",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 186.77675533458688,
+            "scoreError" : 17.009212018160873,
+            "scoreConfidence" : [
+                169.767543316426,
+                203.78596735274775
+            ],
+            "scorePercentiles" : {
+                "0.0" : 175.05638646735977,
+                "50.0" : 184.186261297773,
+                "90.0" : 208.23720977403298,
+                "95.0" : 209.08224910455488,
+                "99.0" : 209.08224910455488,
+                "99.9" : 209.08224910455488,
+                "99.99" : 209.08224910455488,
+                "99.999" : 209.08224910455488,
+                "99.9999" : 209.08224910455488,
+                "100.0" : 209.08224910455488
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    187.88091365558344,
+                    209.08224910455488,
+                    200.63185579933585,
+                    190.52366876189873,
+                    190.70918803439952
+                ],
+                [
+                    177.56072415406365,
+                    177.69099077680156,
+                    180.4916089399626,
+                    178.13996765190905,
+                    175.05638646735977
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.35",
+        "benchmark" : "io.github.joeljeremy7.deezpatch.core.benchmarks.Benchmarks.BenchmarksAvgt.springEvent",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/usr/local/Cellar/openjdk@17/17.0.4.1/libexec/openjdk.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-Xmx2G"
+        ],
+        "jdkVersion" : "17.0.4.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "17.0.4.1+0",
+        "warmupIterations" : 5,
+        "warmupTime" : "5 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "5 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 241.00659812396134,
+            "scoreError" : 1.1696805053930406,
+            "scoreConfidence" : [
+                239.8369176185683,
+                242.17627862935439
+            ],
+            "scorePercentiles" : {
+                "0.0" : 239.95807465170355,
+                "50.0" : 240.9342342482256,
+                "90.0" : 242.68724803407596,
+                "95.0" : 242.8249022167248,
+                "99.0" : 242.8249022167248,
+                "99.9" : 242.8249022167248,
+                "99.99" : 242.8249022167248,
+                "99.999" : 242.8249022167248,
+                "99.9999" : 242.8249022167248,
+                "100.0" : 242.8249022167248
+            },
+            "scoreUnit" : "ns/op",
+            "rawData" : [
+                [
+                    241.0134766459745,
+                    240.73813858391418,
+                    242.8249022167248,
+                    240.8413912634696,
+                    241.17032313050902
+                ],
+                [
+                    241.44836039023625,
+                    240.9767292490808,
+                    240.89173924737042,
+                    240.2028458606305,
+                    239.95807465170355
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+


### PR DESCRIPTION
Replace usage of `WeakConcurrentMap` to `WeakHashMap` in `DeezpatchEventHandlerRegistry`. We don't really need the added thread safety because 99% of the time, items are only put into the map during startup/registration time. 